### PR TITLE
Added default messages for typeMismatch in application-messages #7

### DIFF
--- a/src/main/resources/i18n/application-messages.properties
+++ b/src/main/resources/i18n/application-messages.properties
@@ -21,7 +21,7 @@ typeMismatch.java.lang.Double="{0}" must be a double.
 typeMismatch.java.lang.Float="{0}" must be a float.
 typeMismatch.java.lang.Long="{0}" must be a long.
 typeMismatch.java.lang.Short="{0}" must be a short.
-typeMismatch.java.lang.Boolean="{0}" is not a date.
+typeMismatch.java.lang.Boolean="{0}" is not a boolean.
 typeMismatch.java.util.Date="{0}" is not a date.
 typeMismatch.java.lang.Enum="{0}" is not a valid value.
 


### PR DESCRIPTION
Corrected a mistake in the message of the following key

> typeMismatch.java.lang.Boolean="{0}" is not a boolean.

Please review and merge with master if all OK #7 
