### PR TITLE
[1.0.x] add br tag to make the error page size 513 bytes or more #324

### DIFF
--- a/src/main/webapp/WEB-INF/views/common/error/businessError.jsp
+++ b/src/main/webapp/WEB-INF/views/common/error/businessError.jsp
@@ -34,6 +34,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/error/csrfTokenError.jsp
+++ b/src/main/webapp/WEB-INF/views/common/error/csrfTokenError.jsp
@@ -27,6 +27,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/error/dataAccessError.jsp
+++ b/src/main/webapp/WEB-INF/views/common/error/dataAccessError.jsp
@@ -28,6 +28,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/error/resourceNotFoundError.jsp
+++ b/src/main/webapp/WEB-INF/views/common/error/resourceNotFoundError.jsp
@@ -28,6 +28,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/error/systemError.jsp
+++ b/src/main/webapp/WEB-INF/views/common/error/systemError.jsp
@@ -27,6 +27,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/error/transactionTokenError.jsp
+++ b/src/main/webapp/WEB-INF/views/common/error/transactionTokenError.jsp
@@ -27,6 +27,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/common/error/unhandledSystemError.html
+++ b/src/main/webapp/WEB-INF/views/common/error/unhandledSystemError.html
@@ -22,6 +22,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>


### PR DESCRIPTION
(cherry picked from commit 46948176a08b51be96e8049f7d4407e4a4f6e4d1)

Conflicts:
	src/main/webapp/WEB-INF/views/common/error/accessDeniedError.jsp
	src/main/webapp/WEB-INF/views/common/error/missingCsrfTokenError.jsp

Please review #324 .

This PR is backport for 1.0.x .

Conflicts happened because `accessDeniedError.jsp` and `missingCsrfTokenError.jsp` do not exist in 1.0.x .