### PR TITLE
Update the version of the maven plugin #466

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,8 +240,8 @@
 
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <maven-war-plugin.version>2.5</maven-war-plugin.version>
-        <org.codehaus.mojo.build-helper-maven-plugin.version>1.9.1</org.codehaus.mojo.build-helper-maven-plugin.version>
+        <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
+        <org.codehaus.mojo.build-helper-maven-plugin.version>3.2.0</org.codehaus.mojo.build-helper-maven-plugin.version>
         <!-- == Dependency Versions == -->
         <postgresql.version>42.2.9</postgresql.version>
         <ojdbc.version>19.3.0.0</ojdbc.version>


### PR DESCRIPTION
Please review #466 .

Confirmation:

Check for new warnings or errors due to upgrading plug-ins.

- `maven-war-plugin` : Confirmed that war generation succeeds without warning when `mvn package` is executed.

- `build-helper-maven-plugin` : Configured, but not used in the project, so not tested.