### PR TITLE
[5.6.x]Update the version of the maven plugin #466

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,8 +241,8 @@
 
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <maven-war-plugin.version>2.5</maven-war-plugin.version>
-        <org.codehaus.mojo.build-helper-maven-plugin.version>1.9.1</org.codehaus.mojo.build-helper-maven-plugin.version>
+        <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
+        <org.codehaus.mojo.build-helper-maven-plugin.version>3.2.0</org.codehaus.mojo.build-helper-maven-plugin.version>
         <!-- == Dependency Versions == -->
         <postgresql.version>42.2.9</postgresql.version>
         <ojdbc.version>19.3.0.0</ojdbc.version>


### PR DESCRIPTION
(cherry picked from commit b61a8333b8320f886f4dac00dd989e4bf372b506)

Please review https://github.com/terasolunaorg/terasoluna-gfw-web-blank/issues/468.

Confirmation:

- I did a Grep search for `plugin` to see if there was any other place that managed the plugin version other than the place where I imported it with cherry-pick.

- Check for new warnings or errors due to upgrading plug-ins.

  - `maven-war-plugin` : Confirmed that war generation succeeds without warning when `mvn package` is executed.

  - `build-helper-maven-plugin` : Configured, but not used in the project, so not tested.