### PR TITLE
Fix gitignore settings #483

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ target
 .project
 .springBeans
 *~
-.git
 .idea
 .DS_Store
+tmp
 *.iml


### PR DESCRIPTION
Please review #483 .

Changed gitignore configuration.

The reason I set `tmp` is so that it doesn't include the `tmp` folder that is created when you run `maven-create-archetype.sh`. (`tmp` is set for multi-blank).

