### PR TITLE
Revert "Update Thyemelaf to the latest syntax TSF4J5-7034"

### DIFF
--- a/parts/Thymeleaf/projectName-web/src/main/webapp/WEB-INF/views/common/error/businessError.html
+++ b/parts/Thymeleaf/projectName-web/src/main/webapp/WEB-INF/views/common/error/businessError.html
@@ -10,7 +10,7 @@
             <h1>Business Error!</h1>
             <div class="error">
                 <span th:text="${#strings.isEmpty(exceptionCode)} ? #{e.xx.fw.8001} : |[${exceptionCode}] #{${exceptionCode}}|">[e.xx.fw.8001] Business error occurred!</span>
-                <div th:if="${not #lists.isEmpty(resultMessages)}" class="alert alert-error" th:class="|alert alert-${resultMessages.type}|">
+                <div th:if="${resultMessages} != null" class="alert alert-error" th:class="|alert alert-${resultMessages.type}|">
                     <ul>
                         <li th:each="message : ${resultMessages}" th:text="${message.code} != null ? ${#messages.msgWithParams(message.code, message.args)} : ${message.text}">error detail message</li>
                     </ul>

--- a/parts/Thymeleaf/projectName-web/src/main/webapp/WEB-INF/views/common/error/dataAccessError.html
+++ b/parts/Thymeleaf/projectName-web/src/main/webapp/WEB-INF/views/common/error/dataAccessError.html
@@ -11,7 +11,7 @@
             <div class="error">
                 <span th:text="${#strings.isEmpty(exceptionCode)} ? #{e.xx.fw.9002} : |[${exceptionCode}] #{e.xx.fw.9002}|">[e.xx.fw.9002] Data Access error!</span>
             </div>
-            <div th:if="${not #lists.isEmpty(resultMessages)}" class="alert alert-error" th:class="|alert alert-${resultMessages.type}|">
+            <div th:if="${resultMessages} != null" class="alert alert-error" th:class="|alert alert-${resultMessages.type}|">
                 <ul>
                     <li th:each="message : ${resultMessages}" th:text="${message.code} != null ? ${#messages.msgWithParams(message.code, message.args)} : ${message.text}">error detail message</li>
                 </ul>

--- a/parts/Thymeleaf/projectName-web/src/main/webapp/WEB-INF/views/common/error/resourceNotFoundError.html
+++ b/parts/Thymeleaf/projectName-web/src/main/webapp/WEB-INF/views/common/error/resourceNotFoundError.html
@@ -11,7 +11,7 @@
             <div class="error">
                 <span th:text="${#strings.isEmpty(exceptionCode)} ? #{e.xx.fw.5001} : |[${exceptionCode}] #{e.xx.fw.5001}|">[e.xx.fw.5001] Resource not found.</span>
             </div>
-            <div th:if="${not #lists.isEmpty(resultMessages)}" class="alert alert-error" th:class="|alert alert-${resultMessages.type}|">
+            <div th:if="${resultMessages} != null" class="alert alert-error" th:class="|alert alert-${resultMessages.type}|">
                 <ul>
                     <li th:each="message : ${resultMessages}" th:text="${message.code} != null ? ${#messages.msgWithParams(message.code, message.args)} : ${message.text}">error detail message</li>
                 </ul>


### PR DESCRIPTION
Reverts terasolunaorg/terasoluna-gfw-web-blank#701

ResultMessages is an Iterator, not a List, so it cannot be passed as an argument to lists.isEmpty(). Therefore, revert the change.